### PR TITLE
feat: simplify wdio configuration inheritence

### DIFF
--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -69,22 +69,45 @@ npx nx e2e your-app-name-e2e --configuration=ci
 
 ## Configuration
 
-The @rbnx/webdriverio nx plugin supports two configuration methods, the default configuration option uses the options object in the `project.json` file and will generate the wdio config file when you run the tests.
-An alternative method is to only specify the path to the configuration file in the project.json with the `wdioConfig` property. In this case it will not generate a config file but will use the one specified.
+The @rbnx/webdriverio nx plugin uses an inheritence configuration model, with a base configuration (`wdio.base.config.ts`) in the root of the NX workspace and configuration on project level (`wdio.config.ts`) that extends the base configuration. The project WebdriverIO configuration path is set in the NX project (`project.json`) e2e target options `wdioConfig` property, the target options can also be used to overwrite the base and project configuration.
 
-**NOTE:** For creating a WebdriverIO e2e project with configuration file you can set the flag `auto-config` to `false`
-
-```sh
-npx nx generate @rbnx/webdriverio:project your-app-name --no-auto-config
+```json
+"targets": {
+  "e2e": {
+    "executor": "@rbnx/webdriverio:e2e",
+    "options": {
+      "wdioConfig": "wdio.config.ts"
+    }
+  }
+},
 ```
-
-Regardless of whether you choose configuration via project.json or wdio config, you can use all standard WebdriverIO configuration options.
 
 For all the WebdriverIO configuration options please check the [official documentation](https://webdriver.io/docs/configurationfile) or the [example wdio config file](https://github.com/webdriverio/webdriverio/blob/main/examples/wdio.conf.js) with all possible options.
 
+### DevServer
+
+To automatically start the devServer before the e2e tests are executed you need to provide the configuration option `devServerTarget`.
+
+If `devServerTarget` is provided, the url returned from the started dev server will be passed to WebdriverIO as the baseUrl option.
+
+```json
+  "targets": {
+    "e2e": {
+      "executor": "@rbnx/webdriverio:e2e",
+      "options": {
+        ...
+        "devServerTarget": "your-app-name:serve:development",
+        ...
+      }
+    }
+  },
+```
+
+To skip the execution of the devServer you can overwrite this by providing the `--skipServe` flag.
+
 ### Capabilities
 
-The @rbnx/webdriverio plugin has some predefined capabilities that can be configured with the `browsers` option. The predefined capabilies are:
+The @rbnx/webdriverio plugin has some predefined capabilities that can be configured with the `browsers` option in the project configuration. The predefined capabilies are:
 
 - Chrome
 - Firefox

--- a/packages/webdriverio/src/executors/e2e/executor.spec.ts
+++ b/packages/webdriverio/src/executors/e2e/executor.spec.ts
@@ -41,7 +41,7 @@ describe('Build Executor', () => {
   it('can run', async () => {
     const output = await runExecutor({ wdioConfig: 'wdio.config.ts' }, context);
     expect(execMock).toHaveBeenCalledWith(
-      'npx wdio wdio.config.ts',
+      'npx wdio wdio.generated.config.ts',
       expect.objectContaining({ cwd: './apps/test-e2e' }),
       expect.any(Function)
     );
@@ -95,7 +95,7 @@ describe('Build Executor', () => {
       context
     );
     expect(execMock).toHaveBeenCalledWith(
-      'npx wdio wdio.config.ts --spec=src/e2e/test.spec.ts',
+      'npx wdio wdio.generated.config.ts --spec=src/e2e/test.spec.ts',
       expect.objectContaining({ cwd: './apps/test-e2e' }),
       expect.any(Function)
     );
@@ -114,6 +114,23 @@ describe('Build Executor', () => {
     );
     expect(execMock).toHaveBeenCalledWith(
       'npx wdio wdio.generated.config.ts --suite=test',
+      expect.objectContaining({ cwd: './apps/test-e2e' }),
+      expect.any(Function)
+    );
+    expect(pipe).toHaveBeenCalledTimes(1);
+    expect(output.success).toBe(true);
+  });
+
+  it('should run with specified protocol', async () => {
+    const output = await runExecutor(
+      {
+        specs: ['src/e2e/**/*.spec.ts'],
+        protocol: 'devtools',
+      },
+      context
+    );
+    expect(execMock).toHaveBeenCalledWith(
+      'npx wdio wdio.generated.config.ts',
       expect.objectContaining({ cwd: './apps/test-e2e' }),
       expect.any(Function)
     );

--- a/packages/webdriverio/src/executors/e2e/files/wdio.generated.config.ts__tmpl__
+++ b/packages/webdriverio/src/executors/e2e/files/wdio.generated.config.ts__tmpl__
@@ -1,5 +1,5 @@
 import type { Options } from '@wdio/types';
-import { wdioConfig } from '<%= offsetFromRoot %>wdio.base.config';
+import { <%= options.baseConfigModuleName %> } from '<%= options.baseConfigPath %>';
 
 export const config: Options.Testrunner = {
   ...wdioConfig,

--- a/packages/webdriverio/src/executors/e2e/lib/normalize-options.ts
+++ b/packages/webdriverio/src/executors/e2e/lib/normalize-options.ts
@@ -1,4 +1,10 @@
-import { ExecutorContext, joinPathFragments } from '@nrwl/devkit';
+import {
+  ExecutorContext,
+  joinPathFragments,
+  offsetFromRoot,
+} from '@nrwl/devkit';
+import Path from 'node:path';
+import { capabilitiesFilter } from '../../../wdio';
 import type { NormalizedSchema, Schema } from '../schema';
 
 export function normalizeOptions(
@@ -8,16 +14,36 @@ export function normalizeOptions(
   const projectName = context.projectName;
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName]?.root ?? '';
-  const configFile = options.wdioConfig
-    ? options.wdioConfig
-    : 'wdio.generated.config.ts';
+
+  const configFile = 'wdio.generated.config.ts';
   const configPath = joinPathFragments(projectRoot, configFile);
+
+  const baseConfigModuleName = options.wdioConfig
+    ? 'config as wdioConfig'
+    : 'wdioConfig';
+  const baseConfigPath = options.wdioConfig
+    ? `./${Path.parse(options.wdioConfig).name}`
+    : joinPathFragments(offsetFromRoot(projectRoot), 'wdio.base.config');
+
   const isVerbose = context.isVerbose;
+
+  if (options.browsers) {
+    options.capabilities = capabilitiesFilter(options);
+  }
+
+  if (options.protocol) {
+    options.services = [
+      ...(options.services ?? []),
+      options.protocol === 'devtools' ? 'devtools' : 'selenium-standalone',
+    ];
+  }
 
   return {
     ...options,
     configFile,
     configPath,
+    baseConfigModuleName,
+    baseConfigPath,
     isVerbose,
     projectName,
     projectRoot,

--- a/packages/webdriverio/src/executors/e2e/lib/run-wdio.ts
+++ b/packages/webdriverio/src/executors/e2e/lib/run-wdio.ts
@@ -3,14 +3,12 @@ import {
   generateFiles,
   getPackageManagerCommand,
   joinPathFragments,
-  offsetFromRoot,
   Tree,
   workspaceRoot,
 } from '@nrwl/devkit';
 import { flushChanges, FsTree } from 'nx/src/generators/tree';
 import { exec } from 'node:child_process';
 import { unlink } from 'node:fs/promises';
-import { capabilitiesFilter } from '../../../wdio';
 import type { NormalizedSchema } from '../schema';
 
 export async function runWdio(options: NormalizedSchema) {
@@ -28,23 +26,15 @@ export async function runWdio(options: NormalizedSchema) {
 }
 
 export async function generateWdioConfig(options: NormalizedSchema) {
-  const { wdioConfig, browsers, projectRoot } = options;
-
-  if (wdioConfig) return;
-
-  if (browsers) {
-    options.capabilities = capabilitiesFilter(options);
-  }
+  const { projectRoot } = options;
 
   const tree: Tree = new FsTree(workspaceRoot, false);
   generateFiles(
     tree,
-    joinPathFragments(__dirname, '..', '..', '..', 'wdio', 'files'),
+    joinPathFragments(__dirname, '..', 'files'),
     projectRoot,
     {
       tmpl: '',
-      generated: '.generated',
-      offsetFromRoot: offsetFromRoot(projectRoot),
       options,
     }
   );
@@ -53,9 +43,7 @@ export async function generateWdioConfig(options: NormalizedSchema) {
 }
 
 export async function unlinkWdioConfig(options: NormalizedSchema) {
-  const { configPath, isVerbose, wdioConfig } = options;
-
-  if (wdioConfig) return;
+  const { configPath, isVerbose } = options;
   try {
     await unlink(configPath);
   } catch (error) {

--- a/packages/webdriverio/src/executors/e2e/lib/start-dev-server.ts
+++ b/packages/webdriverio/src/executors/e2e/lib/start-dev-server.ts
@@ -5,24 +5,22 @@ export async function startDevServer(
   options: NormalizedSchema,
   context: ExecutorContext
 ) {
-  if (!options.devServerTarget || options.skipServe) {
-    return options.baseUrl;
+  const { baseUrl, devServerTarget, skipServe } = options;
+  if (!devServerTarget || skipServe) {
+    return baseUrl;
   }
 
-  const devServerTarget = parseTargetString(
-    options.devServerTarget,
-    context.projectGraph
-  );
+  const target = parseTargetString(devServerTarget, context.projectGraph);
 
   for await (const output of await runExecutor<{
     success: boolean;
     baseUrl?: string;
-  }>(devServerTarget, {}, context)) {
+  }>(target, {}, context)) {
     if (!output.success) {
       throw new Error(
-        `Could not start dev server for ${devServerTarget.project} project`
+        `Could not start dev server for ${target.project} project`
       );
     }
-    return options.baseUrl || (output.baseUrl as string);
+    return baseUrl || (output.baseUrl as string);
   }
 }

--- a/packages/webdriverio/src/executors/e2e/schema.d.ts
+++ b/packages/webdriverio/src/executors/e2e/schema.d.ts
@@ -12,6 +12,8 @@ export interface Schema extends WdioOptions {
 export interface NormalizedSchema extends Schema {
   configFile: string;
   configPath: string;
+  baseConfigModuleName: string;
+  baseConfigPath: string;
   isVerbose: boolean;
   projectName: string;
   projectRoot: string;

--- a/packages/webdriverio/src/executors/e2e/schema.json
+++ b/packages/webdriverio/src/executors/e2e/schema.json
@@ -8,8 +8,7 @@
   "properties": {
     "specs": {
       "type": "array",
-      "description": "Define which test specs should run. The pattern is relative to the directory of the configuration file being run.",
-      "default": ["src/e2e/**/*.spec.ts"]
+      "description": "Define which test specs should run. The pattern is relative to the directory of the configuration file being run."
     },
     "spec": {
       "type": "string",
@@ -57,8 +56,7 @@
     },
     "outputDir": {
       "type": "string",
-      "description": "The output directory for the logs, relative to the root configuration of your project.",
-      "default": "./tmp"
+      "description": "The output directory for the logs, relative to the root configuration of your project."
     },
     "bail": {
       "type": "number",

--- a/packages/webdriverio/src/generators/init/files/wdio.base.config.ts__tmpl__
+++ b/packages/webdriverio/src/generators/init/files/wdio.base.config.ts__tmpl__
@@ -2,14 +2,14 @@ import type { Options } from '@wdio/types'
 
 export const wdioConfig: Options.Testrunner = {
   //
-  // ====================
-  // Runner Configuration
-  // ====================
+  // ======================
+  //  Runner Configuration
+  // ======================
   runner: "<%= runner %>",
   //
-  // ============
-  // Capabilities
-  // ============
+  // ==============
+  //  Capabilities
+  // ==============
   // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
   // time. Depending on the number of capabilities, WebdriverIO launches several test
   // sessions.  
@@ -23,9 +23,9 @@ export const wdioConfig: Options.Testrunner = {
   // This is mostly used within CI/CD environments where no display is used.
   headless: false,
   //
-  // ===================
-  // Test Configurations
-  // ===================
+  // =====================
+  //  Test Configurations
+  // =====================
   // Define all options that are relevant for the WebdriverIO instance here
   //
   // Level of logging verbosity: trace | debug | info | warn | error | silent
@@ -54,9 +54,9 @@ export const wdioConfig: Options.Testrunner = {
   // Default request retries count
   connectionRetryCount: 3,
   //
-  // =======================
-  // Framework Configuration
-  // =======================
+  // =========================
+  //  Framework Configuration
+  // =========================
   // Framework you want to run your specs with.
   // The following are supported: Mocha, Jasmine, and Cucumber
   // see also: https://webdriver.io/docs/frameworks
@@ -78,26 +78,26 @@ export const wdioConfig: Options.Testrunner = {
   jasmineOpts: {
     // Jasmine default timeout
     defaultTimeoutInterval: 60000,
-  },<% } %>
+  },<% } %><% 
+  if (services.length) { %>
   //
-  // ======================
-  // Services Configuration
-  // ======================
+  // ========================
+  //  Services Configuration
+  // ========================
   // Test runner services
   // Services take over a specific job you don't want to take care of. They enhance
   // your test setup with almost no effort. Unlike plugins, they don't add new
-  // commands. Instead, they hook themselves up into the test process.<% 
-  if (services.length) { %>
+  // commands. Instead, they hook themselves up into the test process.
   services:  [<%  for (let service of services){ %>'<%= service %>',<% } %>],
-  <% } %>
+  <% } %><% 
+  if (reporters.length) { %>
   //
-  // ======================
-  // Reporter Configuration
-  // ======================
+  // ========================
+  //  Reporter Configuration
+  // ========================
   // Test reporter for stdout.
   // The only one supported by default is 'dot'
-  // see also: https://webdriver.io/docs/dot-reporter<% 
-  if (reporters.length) { %>
+  // see also: https://webdriver.io/docs/dot-reporter
   reporters: [<%  for (let reporter of reporters){ %>'<%= reporter %>',<% } %>],
   <% } %>
 };

--- a/packages/webdriverio/src/generators/project/files/wdio.config.ts__tmpl__
+++ b/packages/webdriverio/src/generators/project/files/wdio.config.ts__tmpl__
@@ -1,0 +1,340 @@
+import type { Options } from '@wdio/types';
+import { wdioConfig } from '<%= offsetFromRoot %>wdio.base.config';
+
+export const config: Options.Testrunner = {
+  ...wdioConfig,
+  //
+  // ==========================
+  //  TypeScript Configuration
+  // ==========================
+  // Autocompile options for TypeScript
+  autoCompileOpts: {
+    autoCompile: true,
+    tsNodeOpts: {
+      transpileOnly: true,
+      project: './tsconfig.json',
+    },
+  },<%
+  if(options.specs || options.exclude) { %>
+  //
+  // ====================
+  //  Specify Test Files
+  // ====================
+  // Define which test specs should run. The pattern is relative to the directory
+  // of the configuration file being run.
+  //
+  // The specs are defined as an array of spec files (optionally using wildcards
+  // that will be expanded). The test for each spec file will be run in a separate
+  // worker process. In order to have a group of spec files run in the same worker
+  // process simply enclose them in an array within the specs array.
+  //<% 
+  if(options.specs) { %>
+  specs: ['<%= options.specs %>'],<% } %><%
+  if(options.exclude) { %>
+  exclude: ['<%= options.exclude %>'],<% } %><% } %><%
+  if(options.maxInstances || options.capabilities) { %>
+  //
+  // ==============
+  //  Capabilities
+  // ==============
+  // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
+  // time. Depending on the number of capabilities, WebdriverIO launches several test
+  // sessions.  
+  //<%
+  if(options.maxInstances) { %>maxInstances: <%= options.maxInstances %>,<% } %><%
+  if(options.maxInstancesPerCapability) { %>maxInstancesPerCapability: <%= options.maxInstancesPerCapability %>,<% } %><%
+  if(options.capabilities) { %>capabilities: <%- JSON.stringify(options.capabilities) %>,<% } %>
+  <% } %><%
+  if(options.logLevel || options.outputDir || options.bail || options.baseUrl || options.waitforTimeout || options.framework) { %>
+  //
+  // =====================
+  //  Test Configurations
+  // =====================
+  // Define all options that are relevant for the WebdriverIO instance here<% 
+  if(options.logLevel) { %>
+  //
+  // Level of logging verbosity: trace | debug | info | warn | error | silent
+  logLevel: '<%= options.logLevel %>',<% } %><% 
+  if(options.outputDir) { %>
+  //
+  // Set directory to store all logs into
+  outputDir: '<%= options.outputDir %>',<% } %><% 
+  if(options.bail) { %>
+  //
+  // If you only want to run your tests until a specific amount of tests have failed use
+  // bail (default is 0 - don't bail, run all tests).
+  bail: <%= options.bail %>,<% } %><% 
+  if(options.baseUrl) { %>
+  //
+  // Set a base URL in order to shorten url command calls. If your `url` parameter starts
+  // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
+  // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
+  // gets prepended directly.
+  baseUrl: '<%= options.baseUrl %>',<% } %><% 
+  if(options.waitforTimeout) { %>
+  //
+  // Default timeout for all waitFor* commands.  
+  waitforTimeout: <%= options.waitforTimeout %>,<% } %><% 
+  if(options.specFileRetries) { %>
+  //
+  // The number of times to retry the entire specfile when it fails as a whole
+  specFileRetries: <%= options.specFileRetries %>,<% } %><%
+  if(options.specFileRetriesDelay) { %>
+  //
+  // Delay in seconds between the spec file retry attempts
+  specFileRetriesDelay: <%= options.specFileRetriesDelay %>,<% } %><%
+  if(options.specFileRetriesDeferred) { %>
+  //
+  // Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
+  specFileRetriesDeferred: <%= options.specFileRetriesDeferred %>,<% } %><% 
+  if(options.framework) { %>
+  //
+  // =========================
+  //  Framework Configuration
+  // =========================
+  // Framework you want to run your specs with.
+  // The following are supported: Mocha, Jasmine, and Cucumber
+  // see also: https://webdriver.io/docs/frameworks
+  //
+  // Make sure you have the wdio adapter package for the specific framework installed before running any tests.  
+  framework: '<%= options.framework %>',<% } %><%
+  if(options.framework === 'mocha') { %>
+  //
+  // Options to be passed to Mocha.
+  // See the full list at http://mochajs.org/  
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000
+  },<% 
+  } else if (options.framework === 'jasmine') { %>
+  //
+  // Options to be passed to Jasmine.
+  jasmineOpts: {
+    // Jasmine default timeout
+    defaultTimeoutInterval: 60000,
+    //
+    // The Jasmine framework allows interception of each assertion in order to log the state of the application
+    // or website depending on the result. For example, it is pretty handy to take a screenshot every time
+    // an assertion fails.
+    expectationResultHandler: function(passed, assertion) {
+        // do something
+    }
+  },<% } %><% } %><% 
+  if(options.services) { %>
+  //
+  // ========================
+  //  Services Configuration
+  // ========================  
+  // Test runner services
+  // Services take over a specific job you don't want to take care of. They enhance
+  // your test setup with almost no effort. Unlike plugins, they don't add new
+  // commands. Instead, they hook themselves up into the test process.
+  services:  [<%  for (let service of options.services){ %>'<%= service %>',<% } %>],<% } %><% 
+  if(options.reporters) { %>
+  //
+  // ========================
+  //  Reporter Configuration
+  // ========================
+  // Test reporter for stdout.
+  // The only one supported by default is 'dot'
+  // see also: https://webdriver.io/docs/dot-reporter
+  reporters: [<%  for (let reporter of options.reporters){ %>'<%= reporter %>',<% } %>],<% } %>
+  //
+  // =======
+  //  Hooks
+  // =======
+  // WebdriverIO provides several hooks you can use to interfere with the test process in order to enhance
+  // it and to build services around it. You can either apply a single function or an array of
+  // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
+  // resolved to continue.
+  /**
+    * Gets executed once before all workers get launched.
+    * @param {Object} config wdio configuration object
+    * @param {Array.<Object>} capabilities list of capabilities details
+    */
+  // onPrepare: function (config, capabilities) {
+  // },
+  /**
+    * Gets executed before a worker process is spawned and can be used to initialise specific service
+    * for that worker as well as modify runtime environments in an async fashion.
+    * @param  {String} cid      capability id (e.g 0-0)
+    * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+    * @param  {[type]} specs    specs to be run in the worker process
+    * @param  {[type]} args     object that will be merged with the main configuration once worker is initialized
+    * @param  {[type]} execArgv list of string arguments passed to the worker process
+    */
+  // onWorkerStart: function (cid, caps, specs, args, execArgv) {
+  // },
+  /**
+    * Gets executed just after a worker process has exited.
+    * @param  {String} cid      capability id (e.g 0-0)
+    * @param  {Number} exitCode 0 - success, 1 - fail
+    * @param  {[type]} specs    specs to be run in the worker process
+    * @param  {Number} retries  number of retries used
+    */
+  // onWorkerEnd: function (cid, exitCode, specs, retries) {
+  // },
+  /**
+    * Gets executed just before initialising the webdriver session and test framework. It allows you
+    * to manipulate configurations depending on the capability or spec.
+    * @param {Object} config wdio configuration object
+    * @param {Array.<Object>} capabilities list of capabilities details
+    * @param {Array.<String>} specs List of spec file paths that are to be run
+    * @param {String} cid worker id (e.g. 0-0)
+    */
+  // beforeSession: function (config, capabilities, specs, cid) {
+  // },
+  /**
+    * Gets executed before test execution begins. At this point you can access to all global
+    * variables like `browser`. It is the perfect place to define custom commands.
+    * @param {Array.<Object>} capabilities list of capabilities details
+    * @param {Array.<String>} specs        List of spec file paths that are to be run
+    * @param {Object}         browser      instance of created browser/device session
+    */
+  // before: function (capabilities, specs) {
+  // },
+  /**
+    * Runs before a WebdriverIO command gets executed.
+    * @param {String} commandName hook command name
+    * @param {Array} args arguments that command would receive
+    */
+  // beforeCommand: function (commandName, args) {
+  // },<%
+  if(options.framework === 'mocha' || options.framework === 'jasmine') { %>
+  /**
+    * Hook that gets executed before the suite starts
+    * @param {Object} suite suite details
+    */
+  // beforeSuite: function (suite) {
+  // },
+  /**
+    * Function to be executed before a test (in Mocha/Jasmine only)
+    * @param {Object} test    test object
+    * @param {Object} context scope object the test was executed with
+    */
+  // beforeTest: function (test, context) {
+  // },
+  /**
+    * This hook gets executed _before_ every hook within the suite starts.
+    * (For example, this runs before calling `before`, `beforeEach`, `after`, `afterEach` in Mocha.). 
+    *
+    */
+  // beforeHook: function (test, context) {
+  // },
+  /**
+    * Hook that gets executed _after_ every hook within the suite ends.
+    * (For example, this runs after calling `before`, `beforeEach`, `after`, `afterEach` in Mocha.). 
+    */
+  // afterHook: function (test, context, { error, result, duration, passed, retries }) {
+  // },
+  /**
+    * Hook that gets executed after the suite has ended
+    * @param {Object} suite suite details
+    */
+  // afterSuite: function (suite) {
+  // },<% }
+  if(options.framework === 'cucumber') { %>
+  /**
+    * Cucumber Hooks
+    *
+    * Runs before a Cucumber Feature.
+    * @param {String}                   uri      path to feature file
+    * @param {GherkinDocument.IFeature} feature  Cucumber feature object
+    */
+  // beforeFeature: function (uri, feature) {
+  // },
+  /**
+    *
+    * Runs before a Cucumber Scenario.
+    * @param {ITestCaseHookParameter} world    world object containing information on pickle and test step
+    * @param {Object}                 context  Cucumber World object
+    */
+  // beforeScenario: function (world, context) {
+  // },
+  /**
+    *
+    * Runs before a Cucumber Step.
+    * @param {Pickle.IPickleStep} step     step data
+    * @param {IPickle}            scenario scenario pickle
+    * @param {Object}             context  Cucumber World object
+    */
+  // beforeStep: function (step, scenario, context) {
+  // },
+  /**
+    *
+    * Runs after a Cucumber Step.
+    * @param {Pickle.IPickleStep} step             step data
+    * @param {IPickle}            scenario         scenario pickle
+    * @param {Object}             result           results object containing scenario results
+    * @param {boolean}            result.passed    true if scenario has passed
+    * @param {string}             result.error     error stack if scenario failed
+    * @param {number}             result.duration  duration of scenario in milliseconds
+    * @param {Object}             context          Cucumber World object
+    */
+  // afterStep: function (step, scenario, result, context) {
+  // },
+  /**
+    *
+    * Runs after a Cucumber Scenario.
+    * @param {ITestCaseHookParameter} world            world object containing information on pickle and test step
+    * @param {Object}                 result           results object containing scenario results
+    * @param {boolean}                result.passed    true if scenario has passed
+    * @param {string}                 result.error     error stack if scenario failed
+    * @param {number}                 result.duration  duration of scenario in milliseconds
+    * @param {Object}                 context          Cucumber World object
+    */
+  // afterScenario: function (world, result, context) {
+  // },
+  /**
+    *
+    * Runs after a Cucumber Feature.
+    * @param {String}                   uri      path to feature file
+    * @param {GherkinDocument.IFeature} feature  Cucumber feature object
+    */
+  // afterFeature: function (uri, feature) {
+  // },
+  <% } %>
+  /**
+    * Runs after a WebdriverIO command gets executed
+    * @param {String} commandName hook command name
+    * @param {Array} args arguments that command would receive
+    * @param {Number} result 0 - command success, 1 - command error
+    * @param {Object} error error object if any
+    */
+  // afterCommand: function (commandName, args, result, error) {
+  // },
+  /**
+    * Gets executed after all tests are done. You still have access to all global variables from
+    * the test.
+    * @param {Number} result 0 - test pass, 1 - test fail
+    * @param {Array.<Object>} capabilities list of capabilities details
+    * @param {Array.<String>} specs List of spec file paths that ran
+    */
+  // after: function (result, capabilities, specs) {
+  // },
+  /**
+    * Gets executed right after terminating the webdriver session.
+    * @param {Object} config wdio configuration object
+    * @param {Array.<Object>} capabilities list of capabilities details
+    * @param {Array.<String>} specs List of spec file paths that ran
+    */
+  // afterSession: function (config, capabilities, specs) {
+  // },
+  /**
+    * Gets executed after all workers got shut down and the process is about to exit. An error
+    * thrown in the onComplete hook will result in the test run failing.
+    * @param {Object} exitCode 0 - success, 1 - fail
+    * @param {Object} config wdio configuration object
+    * @param {Array.<Object>} capabilities list of capabilities details
+    * @param {<Object>} results object containing test results
+    */
+  // onComplete: function(exitCode, config, capabilities, results) {
+  // },
+  /**
+  * Gets executed when a refresh happens.
+  * @param {String} oldSessionId session ID of the old session
+  * @param {String} newSessionId session ID of the new session
+  */
+  // onReload: function(oldSessionId, newSessionId) {
+  // }
+ };

--- a/packages/webdriverio/src/generators/project/generator.spec.ts
+++ b/packages/webdriverio/src/generators/project/generator.spec.ts
@@ -42,7 +42,6 @@ describe('project generator', () => {
   it('should create wdio config with capabilities', async () => {
     const options: Schema = {
       project: 'test',
-      autoConfig: false,
       protocol: 'devtools',
       browsers: ['firefox'],
       capabilities: [{ browserName: 'chrome' }],

--- a/packages/webdriverio/src/generators/project/lib/add-project-config.ts
+++ b/packages/webdriverio/src/generators/project/lib/add-project-config.ts
@@ -3,7 +3,7 @@ import { filterWdioOptions } from '../../../wdio';
 import type { NormalizedSchema } from '../schema';
 
 export function addProjectConfig(tree: Tree, options: NormalizedSchema) {
-  const { autoConfig, parsedTags, projectRoot, project } = options;
+  const { parsedTags, projectRoot, project } = options;
   const e2eProjectName = project + '-e2e';
 
   addProjectConfiguration(tree, e2eProjectName, {
@@ -13,9 +13,10 @@ export function addProjectConfig(tree: Tree, options: NormalizedSchema) {
     targets: {
       e2e: {
         executor: '@rbnx/webdriverio:e2e',
-        options: !autoConfig
-          ? { wdioConfig: 'wdio.config.ts' }
-          : filterWdioOptions(options),
+        options: {
+          wdioConfig: 'wdio.config.ts',
+          ...filterWdioOptions(options),
+        },
       },
     },
     tags: parsedTags,

--- a/packages/webdriverio/src/generators/project/lib/add-project-files.ts
+++ b/packages/webdriverio/src/generators/project/lib/add-project-files.ts
@@ -9,7 +9,7 @@ import { capabilitiesFilter } from '../../../wdio';
 import type { NormalizedSchema } from '../schema';
 
 export function addProjectFiles(tree: Tree, options: NormalizedSchema) {
-  const { autoConfig, projectRoot } = options;
+  const { projectRoot } = options;
 
   const framework =
     options.framework ?? readPropertyFromConfig(tree, 'framework').shift();
@@ -22,14 +22,17 @@ export function addProjectFiles(tree: Tree, options: NormalizedSchema) {
 
   const templateOptions = {
     options,
-    offsetFromRoot: offsetFromRoot(projectRoot),
     framework,
     protocol: options.protocol ?? getProtocol(services),
     wdioFrameworkType: getFrameWorkTypePackage(framework),
     wdioServiceTypes: getServiceTypePackage(services),
-    generated: '',
+    offsetFromRoot: offsetFromRoot(projectRoot),
     tmpl: '',
   };
+
+  if (options.browsers) {
+    options.capabilities = capabilitiesFilter(options);
+  }
 
   generateFiles(
     tree,
@@ -37,19 +40,6 @@ export function addProjectFiles(tree: Tree, options: NormalizedSchema) {
     projectRoot,
     templateOptions
   );
-
-  if (!autoConfig) {
-    if (options.browsers) {
-      options.capabilities = capabilitiesFilter(options);
-    }
-
-    generateFiles(
-      tree,
-      joinPathFragments(__dirname, '..', '..', '..', 'wdio', 'files'),
-      projectRoot,
-      templateOptions
-    );
-  }
 }
 
 function getFrameWorkTypePackage(framework: string) {

--- a/packages/webdriverio/src/generators/project/lib/normalize-options.ts
+++ b/packages/webdriverio/src/generators/project/lib/normalize-options.ts
@@ -1,4 +1,9 @@
-import { getWorkspaceLayout, names, Tree } from '@nrwl/devkit';
+import {
+  getWorkspaceLayout,
+  joinPathFragments,
+  names,
+  Tree,
+} from '@nrwl/devkit';
 import type { NormalizedSchema, Schema } from '../schema';
 
 export function normalizeOptions(
@@ -8,7 +13,6 @@ export function normalizeOptions(
   const project = names(options.project).fileName;
   const e2eProjectName = project + '-e2e';
 
-  options.autoConfig = options.autoConfig ?? true;
   if (options.protocol) {
     options.services = [
       ...(options.services ?? []),
@@ -18,7 +22,11 @@ export function normalizeOptions(
 
   const projectDirectory = e2eProjectName;
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
-  const projectRoot = `${getWorkspaceLayout(tree).appsDir}/${projectDirectory}`;
+  const projectRoot = joinPathFragments(
+    getWorkspaceLayout(tree).appsDir,
+    projectDirectory
+  );
+
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())
     : [];

--- a/packages/webdriverio/src/generators/project/schema.d.ts
+++ b/packages/webdriverio/src/generators/project/schema.d.ts
@@ -6,7 +6,6 @@ export interface Schema extends WdioOptions {
   browsers?: BrowserName[];
   protocol?: Protocol;
   wdioConfig?: string;
-  autoConfig?: boolean;
   skipFormat?: boolean;
 }
 

--- a/packages/webdriverio/src/generators/project/schema.json
+++ b/packages/webdriverio/src/generators/project/schema.json
@@ -90,11 +90,6 @@
       "type": "number",
       "description": "The number of times to retry the entire specfile when it fails."
     },
-    "autoConfig": {
-      "type": "boolean",
-      "description": "Auto generate wdio configuration.",
-      "default": true
-    },
     "skipFormat": {
       "type": "boolean",
       "description": "Skip formatting files.",

--- a/packages/webdriverio/src/wdio/options.ts
+++ b/packages/webdriverio/src/wdio/options.ts
@@ -25,6 +25,7 @@ export interface WdioOptions {
   path?: string;
   waitforTimeout?: number;
   framework?: Framework;
+  protocol?: Protocol;
   reporters?: Reporters[];
   services?: Services[];
   specFileRetries?: number;
@@ -34,30 +35,7 @@ export interface WdioOptions {
 
 type wdioOptsKeys = keyof WdioOptions;
 
-const wdioOpts: wdioOptsKeys[] = [
-  'specs',
-  'exclude',
-  'suites',
-  'maxInstances',
-  'maxInstancesPerCapability',
-  'browsers',
-  'capabilities',
-  'headless',
-  'logLevel',
-  'outputDir',
-  'bail',
-  'baseUrl',
-  'hostname',
-  'port',
-  'path',
-  'waitforTimeout',
-  'framework',
-  'reporters',
-  'services',
-  'specFileRetries',
-  'specFileRetriesDelay',
-  'specFileRetriesDeferred',
-];
+const wdioOpts: wdioOptsKeys[] = ['browsers', 'headless', 'protocol'];
 
 export function filterWdioOptions(obj): WdioOptions {
   return Object.fromEntries(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/roozenboom/rbnx/blob/master/CONTRIBUTING.md -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(scope): must begin with lowercase` -->

## Current Behavior
The configuration supports two different methods which makes it unnecessarily complex. Not all wdio options can be set with the autoConfig method because they were not mapped correctly in the generated configuration.
<!-- This is the behavior we have today -->

## Expected Behavior
By removing the autoConfig method and using configuration inheritance you can set all wdio options and hooks on project level. When the e2e tests are executed the configuration from the project.json will overwrite the project and base configuration.  
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
