### PR TITLE
feat: add option to automatically configure wdio for debugging

### DIFF
--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -95,9 +95,7 @@ If `devServerTarget` is provided, the url returned from the started dev server w
     "e2e": {
       "executor": "@rbnx/webdriverio:e2e",
       "options": {
-        ...
         "devServerTarget": "your-app-name:serve:development",
-        ...
       }
     }
   },
@@ -145,6 +143,28 @@ A WebdriverIO service that allows you to use the native browser interface [DevTo
 
 **Selenium Standalone Service**
 Handling the Selenium server is out of the scope of the actual WebdriverIO project. This service helps you to run Selenium seamlessly when running tests with the WDIO testrunner. It uses the well-known selenium-standalone NPM package that automatically sets up the standalone server and all required drivers for you.
+
+## Debugging
+
+You can enable debug mode when you run your e2e project by providing the `--debug` flag.
+
+```sh
+npx nx e2e your-app-name-e2e --spec=src/e2e/app.spec.ts --debug
+```
+
+This flag will change some of the WebdriverIO settings:
+
+- logLevel: debug
+- maxInstances: 1
+- timeout: 2147483647
+
+To activate the debug mode in your spec file you have to add
+
+```ts
+await browser.debug();
+```
+
+Read the documentation for more information about [debugging](https://webdriver.io/docs/debugging) with WebdriverIO
 
 ## That's all!
 

--- a/packages/webdriverio/src/executors/e2e/executor.ts
+++ b/packages/webdriverio/src/executors/e2e/executor.ts
@@ -1,4 +1,5 @@
-import { ExecutorContext } from '@nrwl/devkit';
+import { ExecutorContext, Tree, workspaceRoot } from '@nrwl/devkit';
+import { FsTree } from 'nx/src/generators/tree';
 import { normalizeOptions } from './lib/normalize-options';
 import { generateWdioConfig, runWdio, unlinkWdioConfig } from './lib/run-wdio';
 import { startDevServer } from './lib/start-dev-server';
@@ -8,11 +9,13 @@ export default async function runExecutor(
   options: Schema,
   context: ExecutorContext
 ) {
-  const wdioOptions = normalizeOptions(options, context);
+  const tree: Tree = new FsTree(workspaceRoot, false);
+
+  const wdioOptions = normalizeOptions(tree, options, context);
   try {
     wdioOptions.baseUrl = await startDevServer(wdioOptions, context);
 
-    await generateWdioConfig(wdioOptions);
+    await generateWdioConfig(tree, wdioOptions);
     await runWdio(wdioOptions);
     await unlinkWdioConfig(wdioOptions);
 

--- a/packages/webdriverio/src/executors/e2e/files/wdio.generated.config.ts__tmpl__
+++ b/packages/webdriverio/src/executors/e2e/files/wdio.generated.config.ts__tmpl__
@@ -14,6 +14,7 @@ export const config: Options.Testrunner = {
   if(options.maxInstances) { %>maxInstances: <%= options.maxInstances %>,<% } %><%
   if(options.maxInstancesPerCapability) { %>maxInstancesPerCapability: <%= options.maxInstancesPerCapability %>,<% } %><%
   if(options.capabilities) { %>capabilities: <%- JSON.stringify(options.capabilities) %>,<% } %><% 
+  if(options.debug) { %>execArgv: ['--inspect'],<% } %><% 
   if(options.logLevel) { %>logLevel: '<%= options.logLevel %>',<% } %><% 
   if(options.outputDir) { %>outputDir: '<%= options.outputDir %>',<% } %><% 
   if(options.bail) { %>bail: <%= options.bail %>,<% } %><% 
@@ -23,11 +24,11 @@ export const config: Options.Testrunner = {
   if(options.framework === 'mocha') { %>
   mochaOpts: {
     ui: 'bdd',
-    timeout: 60000
+    timeout: <%= options.timeout %>
   },<% 
   } else if (options.framework === 'jasmine') { %>
   jasmineOpts: {
-    defaultTimeoutInterval: 60000,
+    defaultTimeoutInterval: <%= options.timeout %>,
   },<% } %><% 
   if(options.services) { %>services:  [<%  for (let service of options.services){ %>'<%= service %>',<% } %>],<% } %><% 
   if(options.reporters) { %>reporters: [<%  for (let reporter of options.reporters){ %>'<%= reporter %>',<% } %>],<% } %><% 

--- a/packages/webdriverio/src/executors/e2e/lib/normalize-options.spec.ts
+++ b/packages/webdriverio/src/executors/e2e/lib/normalize-options.spec.ts
@@ -1,0 +1,55 @@
+import { Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { normalizeOptions } from './normalize-options';
+import type { Schema } from '../schema';
+
+describe('normalize options', () => {
+  let tree: Tree;
+  const options: Schema = {
+    framework: 'mocha',
+    wdioConfig: 'wdio.config.ts',
+  };
+
+  const context = {
+    root: '/root',
+    projectName: 'test-e2e',
+    projectsConfigurations: {
+      version: 2,
+      projects: {
+        'test-e2e': {
+          root: './apps/test-e2e',
+        },
+      },
+    },
+    nxJsonConfiguration: {
+      npmScope: 'test',
+    },
+    isVerbose: true,
+    cwd: '/root',
+  };
+
+  beforeAll(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    tree.write(
+      './apps/test-e2e/wdio.config.ts',
+      `export const config: { framework:'jasmine' }`
+    );
+
+    console.log(tree.exists('./apps/test-e2e/wdio.config.ts'));
+  });
+
+  it('should normalize options', async () => {
+    const output = normalizeOptions(tree, options, context);
+
+    expect(output.projectRoot).toEqual('./apps/test-e2e');
+    expect(output.timeout).toEqual(60000);
+  });
+
+  it('should normalize debug options', async () => {
+    const output = normalizeOptions(tree, { ...options, debug: true }, context);
+
+    expect(output.logLevel).toEqual('debug');
+    expect(output.timeout).toBeGreaterThan(60000);
+  });
+});

--- a/packages/webdriverio/src/executors/e2e/lib/run-wdio.ts
+++ b/packages/webdriverio/src/executors/e2e/lib/run-wdio.ts
@@ -6,7 +6,7 @@ import {
   Tree,
   workspaceRoot,
 } from '@nrwl/devkit';
-import { flushChanges, FsTree } from 'nx/src/generators/tree';
+import { flushChanges } from 'nx/src/generators/tree';
 import { exec } from 'node:child_process';
 import { unlink } from 'node:fs/promises';
 import type { NormalizedSchema } from '../schema';
@@ -25,10 +25,12 @@ export async function runWdio(options: NormalizedSchema) {
   });
 }
 
-export async function generateWdioConfig(options: NormalizedSchema) {
+export async function generateWdioConfig(
+  tree: Tree,
+  options: NormalizedSchema
+) {
   const { projectRoot } = options;
 
-  const tree: Tree = new FsTree(workspaceRoot, false);
   generateFiles(
     tree,
     joinPathFragments(__dirname, '..', 'files'),

--- a/packages/webdriverio/src/executors/e2e/schema.d.ts
+++ b/packages/webdriverio/src/executors/e2e/schema.d.ts
@@ -7,6 +7,7 @@ export interface Schema extends WdioOptions {
   wdioConfig?: string;
   devServerTarget?: string;
   skipServe?: boolean;
+  debug?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {
@@ -17,4 +18,5 @@ export interface NormalizedSchema extends Schema {
   isVerbose: boolean;
   projectName: string;
   projectRoot: string;
+  timeout: number;
 }

--- a/packages/webdriverio/src/generators/project/lib/add-project-files.ts
+++ b/packages/webdriverio/src/generators/project/lib/add-project-files.ts
@@ -1,22 +1,22 @@
-import { createSourceFile, Node, ScriptTarget, SyntaxKind } from 'typescript';
 import {
   generateFiles,
   joinPathFragments,
   offsetFromRoot,
   Tree,
 } from '@nrwl/devkit';
-import { capabilitiesFilter } from '../../../wdio';
+import { capabilitiesFilter, readPropertyFromConfig } from '../../../wdio';
 import type { NormalizedSchema } from '../schema';
 
 export function addProjectFiles(tree: Tree, options: NormalizedSchema) {
   const { projectRoot } = options;
 
   const framework =
-    options.framework ?? readPropertyFromConfig(tree, 'framework').shift();
+    options.framework ??
+    readPropertyFromConfig(tree, 'wdio.base.config.ts', 'framework').shift();
   const services = [
     ...new Set([
       ...(options.services ?? []),
-      ...readPropertyFromConfig(tree, 'services'),
+      ...readPropertyFromConfig(tree, 'wdio.base.config.ts', 'services'),
     ]),
   ];
 
@@ -62,61 +62,4 @@ function getServiceTypePackage(services: string[]) {
 
 function getProtocol(services: string[]) {
   return services.includes('devtools') ? 'devtools' : 'webdriver';
-}
-
-function readPropertyFromConfig(tree: Tree, prop: string) {
-  const baseConfigPath = 'wdio.base.config.ts';
-
-  if (tree.exists(baseConfigPath)) {
-    const source = createSourceFile(
-      baseConfigPath,
-      tree.read(baseConfigPath, 'utf-8'),
-      ScriptTarget.Latest,
-      true
-    );
-
-    const propNode = findNodes(source, SyntaxKind.PropertyAssignment)
-      .filter((node: Node) => node.getText().startsWith(prop))
-      .shift();
-
-    return findNodes(propNode, SyntaxKind.StringLiteral).map((node) =>
-      node.getText().replace(/['"]/g, '')
-    );
-  }
-}
-
-function findNodes(
-  node: Node,
-  kind: SyntaxKind | SyntaxKind[],
-  max = Infinity
-): Node[] {
-  if (!node || max == 0) {
-    return [];
-  }
-
-  const nodes: Node[] = [];
-  const match = Array.isArray(kind)
-    ? kind.includes(node.kind)
-    : node.kind === kind;
-
-  if (match) {
-    nodes.push(node);
-    max--;
-  }
-  if (max > 0) {
-    for (const child of node.getChildren()) {
-      findNodes(child, kind, max).forEach((node) => {
-        if (max > 0) {
-          nodes.push(node);
-        }
-        max--;
-      });
-
-      if (max <= 0) {
-        break;
-      }
-    }
-  }
-
-  return nodes;
 }

--- a/packages/webdriverio/src/wdio/config.ts
+++ b/packages/webdriverio/src/wdio/config.ts
@@ -1,0 +1,61 @@
+import { Tree } from '@nrwl/devkit';
+import { createSourceFile, Node, ScriptTarget, SyntaxKind } from 'typescript';
+
+export function readPropertyFromConfig<T = string>(
+  tree: Tree,
+  config: string,
+  prop: string
+) {
+  if (tree.exists(config)) {
+    const source = createSourceFile(
+      config,
+      tree.read(config, 'utf-8'),
+      ScriptTarget.Latest,
+      true
+    );
+
+    const propNode = findNodes(source, SyntaxKind.PropertyAssignment)
+      .filter((node: Node) => node.getText().startsWith(prop))
+      .shift();
+
+    return findNodes(propNode, SyntaxKind.StringLiteral).map<T>(
+      (node) => node.getText().replace(/['"]/g, '') as T
+    );
+  }
+}
+
+function findNodes(
+  node: Node,
+  kind: SyntaxKind | SyntaxKind[],
+  max = Infinity
+): Node[] {
+  if (!node || max == 0) {
+    return [];
+  }
+
+  const nodes: Node[] = [];
+  const match = Array.isArray(kind)
+    ? kind.includes(node.kind)
+    : node.kind === kind;
+
+  if (match) {
+    nodes.push(node);
+    max--;
+  }
+  if (max > 0) {
+    for (const child of node.getChildren()) {
+      findNodes(child, kind, max).forEach((node) => {
+        if (max > 0) {
+          nodes.push(node);
+        }
+        max--;
+      });
+
+      if (max <= 0) {
+        break;
+      }
+    }
+  }
+
+  return nodes;
+}

--- a/packages/webdriverio/src/wdio/index.ts
+++ b/packages/webdriverio/src/wdio/index.ts
@@ -1,2 +1,3 @@
 export * from './capabilities';
+export * from './config';
 export * from './options';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/roozenboom/rbnx/blob/master/CONTRIBUTING.md -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(scope): must begin with lowercase` -->

## Current Behavior

<!-- This is the behavior we have today -->

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Add the possibility to automatically configure WebdriverIO for debugging, by providing the `--debug` flag. 
It updates the maxInstances, logLevel and timeout settings, see also https://webdriver.io/docs/debugging

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
