### PR TITLE
feat: add option to enable wdio watch mode

### DIFF
--- a/packages/webdriverio/src/executors/e2e/lib/run-wdio.ts
+++ b/packages/webdriverio/src/executors/e2e/lib/run-wdio.ts
@@ -12,16 +12,22 @@ import { unlink } from 'node:fs/promises';
 import type { NormalizedSchema } from '../schema';
 
 export async function runWdio(options: NormalizedSchema) {
-  const { projectRoot, configFile, spec, suite } = options;
+  const { projectRoot, configFile, spec, suite, watch } = options;
 
   let command = `${getPackageManagerCommand().exec} wdio ${configFile}`;
   if (spec) command += ` --spec=${spec}`;
   if (suite) command += ` --suite=${suite}`;
+  if (watch) command += ` --watch`;
 
   await new Promise((resolve, reject) => {
     exec(command, { cwd: projectRoot }, (error, stdout, stderr) => {
       error ? reject(error) : resolve({ stdout, stderr });
     }).stdout.pipe(process.stdout);
+
+    if (watch) {
+      process.on('SIGINT', () => resolve({}));
+      process.on('SIGTERM', () => resolve({}));
+    }
   });
 }
 

--- a/packages/webdriverio/src/executors/e2e/schema.d.ts
+++ b/packages/webdriverio/src/executors/e2e/schema.d.ts
@@ -7,6 +7,7 @@ export interface Schema extends WdioOptions {
   wdioConfig?: string;
   devServerTarget?: string;
   skipServe?: boolean;
+  watch?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/webdriverio/src/executors/e2e/schema.json
+++ b/packages/webdriverio/src/executors/e2e/schema.json
@@ -91,6 +91,15 @@
       "type": "boolean",
       "description": "Skip dev server target execution.",
       "default": false
+    },
+    "watch": {
+      "type": "boolean",
+      "description": "Watch for file changes and automatically rerun tests",
+      "default": false
+    },
+    "filesToWatch": {
+      "type": "array",
+      "description": "Add files to watch (e.g. application code or page objects) when running `wdio` command with `--watch` flag. Globbing is supported."
     }
   },
   "required": []

--- a/packages/webdriverio/src/generators/project/files/.gitignore__tmpl__
+++ b/packages/webdriverio/src/generators/project/files/.gitignore__tmpl__
@@ -1,0 +1,2 @@
+# @rbnx/webdriverio - auto-generated configuration file
+wdio.generated.config.ts

--- a/packages/webdriverio/src/wdio/options.ts
+++ b/packages/webdriverio/src/wdio/options.ts
@@ -31,6 +31,7 @@ export interface WdioOptions {
   specFileRetries?: number;
   specFileRetriesDelay?: number;
   specFileRetriesDeferred?: boolean;
+  filesToWatch?: string;
 }
 
 type wdioOptsKeys = keyof WdioOptions;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/roozenboom/rbnx/blob/master/CONTRIBUTING.md -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(scope): must begin with lowercase` -->

## Current Behavior

<!-- This is the behavior we have today -->
The `--watch` flag is not supported.
## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Add support for WebdriverIO watch mode (https://webdriver.io/docs/watcher/) by adding a watch parameter to the executor schema and forwarding the `--watch` flag to the wdio cli command. 
Additional files to watch (glob patterns) can be configured with the wdio config property `filesToWatch`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5
