### PR TITLE
Allow `options.wdioConfig` to support absolute and relative paths

### DIFF
--- a/packages/webdriverio/src/executors/e2e/lib/normalize-options.spec.ts
+++ b/packages/webdriverio/src/executors/e2e/lib/normalize-options.spec.ts
@@ -43,6 +43,7 @@ describe('normalize options', () => {
     const output = normalizeOptions(tree, options, context);
 
     expect(output.projectRoot).toEqual('./apps/test-e2e');
+    expect(output.baseConfigPath).toEqual('./wdio.config');
     expect(output.timeout).toEqual(60000);
   });
 
@@ -51,5 +52,49 @@ describe('normalize options', () => {
 
     expect(output.logLevel).toEqual('debug');
     expect(output.timeout).toBeGreaterThan(60000);
+  });
+
+  it('should normalize relative wdioConfig paths', async () => {
+    const output1 = normalizeOptions(
+      tree,
+      { ...options, wdioConfig: 'config/wdio.config.ts' },
+      context
+    );
+    const output2 = normalizeOptions(
+      tree,
+      { ...options, wdioConfig: './config/wdio.config.ts' },
+      context
+    );
+    const output3 = normalizeOptions(
+      tree,
+      { ...options, wdioConfig: '../../config/wdio.config.ts' },
+      context
+    );
+    const output4 = normalizeOptions(
+      tree,
+      { ...options, wdioConfig: '.wdio.config.ts' },
+      context
+    );
+    const output5 = normalizeOptions(
+      tree,
+      { ...options, wdioConfig: '.config/wdio.config.ts' },
+      context
+    );
+
+    expect(output1.baseConfigPath).toEqual('./config/wdio.config');
+    expect(output2.baseConfigPath).toEqual('./config/wdio.config');
+    expect(output3.baseConfigPath).toEqual('../../config/wdio.config');
+    expect(output4.baseConfigPath).toEqual('./.wdio.config');
+    expect(output5.baseConfigPath).toEqual('./.config/wdio.config');
+  });
+
+  it('should normalize absolute wdioConfig paths', async () => {
+    const output = normalizeOptions(
+      tree,
+      { ...options, wdioConfig: '/config/wdio.config.ts' },
+      context
+    );
+
+    expect(output.baseConfigPath).toEqual('/config/wdio.config');
   });
 });

--- a/packages/webdriverio/src/executors/e2e/lib/normalize-options.ts
+++ b/packages/webdriverio/src/executors/e2e/lib/normalize-options.ts
@@ -27,9 +27,24 @@ export function normalizeOptions(
   const baseConfigModuleName = options.wdioConfig
     ? 'config as wdioConfig'
     : 'wdioConfig';
-  const baseConfigPath = options.wdioConfig
-    ? `./${Path.parse(options.wdioConfig).name}`
-    : joinPathFragments(offsetFromRoot(projectRoot), 'wdio.base.config');
+
+  let baseConfigPath: string;
+  if (options.wdioConfig) {
+    const parsedPath = Path.parse(options.wdioConfig);
+    baseConfigPath = joinPathFragments(parsedPath.dir, parsedPath.name);
+    if (!Path.isAbsolute(options.wdioConfig)) {
+      if (
+        !(baseConfigPath.startsWith('./') || baseConfigPath.startsWith('../'))
+      ) {
+        baseConfigPath = `./${baseConfigPath}`;
+      }
+    }
+  } else {
+    baseConfigPath = joinPathFragments(
+      offsetFromRoot(projectRoot),
+      'wdio.base.config'
+    );
+  }
 
   const isVerbose = context.isVerbose;
 


### PR DESCRIPTION
## Current Behavior
options.wdioConfig must be located in the project root, else generated wdio config improperly references the file.

## Expected Behavior
`options.wdioConfig` should support config files located at arbitrary file system locations.
The generated wdio config file should properly reference the config file in its import statement.