### PR TITLE
fix: use wdio configPath relative from workspace root to run wdio

### DIFF
--- a/e2e/webdriverio-e2e/tests/defaults.spec.ts
+++ b/e2e/webdriverio-e2e/tests/defaults.spec.ts
@@ -55,13 +55,15 @@ describe('webdriverio e2e - defaults', () => {
     expect(() => checkFilesExist(projectJsonPath)).not.toThrow();
 
     const projectJson = readJson(projectJsonPath);
-    expect(
-      projectJson.targets.e2e.executor === '@rbnx/webdriverio:e2e'
-    ).toBeTruthy();
+    expect(projectJson.targets.e2e.executor).toBe('@rbnx/webdriverio:e2e');
 
-    expect(
-      projectJson.targets.e2e.options.wdioConfig === 'wdio.config.ts'
-    ).toBeTruthy();
+    const wdioConfigPath = joinPathFragments(
+      'apps',
+      e2eProject,
+      'wdio.config.ts'
+    );
+    expect(projectJson.targets.e2e.options.wdioConfig).toBe(wdioConfigPath);
+    expect(() => checkFilesExist(wdioConfigPath)).not.toThrow();
 
     const tsConfigJsonPath = joinPathFragments(
       'apps',

--- a/packages/webdriverio/src/executors/e2e/executor.spec.ts
+++ b/packages/webdriverio/src/executors/e2e/executor.spec.ts
@@ -41,8 +41,8 @@ describe('Build Executor', () => {
   it('can run', async () => {
     const output = await runExecutor({ wdioConfig: 'wdio.config.ts' }, context);
     expect(execMock).toHaveBeenCalledWith(
-      'npx wdio wdio.generated.config.ts',
-      expect.objectContaining({ cwd: './apps/test-e2e' }),
+      'npx wdio apps/test-e2e/wdio.generated.config.ts',
+      expect.objectContaining({}),
       expect.any(Function)
     );
     expect(pipe).toHaveBeenCalledTimes(1);
@@ -59,8 +59,8 @@ describe('Build Executor', () => {
       context
     );
     expect(execMock).toHaveBeenCalledWith(
-      'npx wdio wdio.generated.config.ts',
-      expect.objectContaining({ cwd: './apps/test-e2e' }),
+      'npx wdio apps/test-e2e/wdio.generated.config.ts',
+      expect.objectContaining({}),
       expect.any(Function)
     );
     expect(pipe).toHaveBeenCalledTimes(1);
@@ -78,8 +78,8 @@ describe('Build Executor', () => {
       context
     );
     expect(execMock).toHaveBeenCalledWith(
-      'npx wdio wdio.generated.config.ts',
-      expect.objectContaining({ cwd: './apps/test-e2e' }),
+      'npx wdio apps/test-e2e/wdio.generated.config.ts',
+      expect.objectContaining({}),
       expect.any(Function)
     );
     expect(pipe).toHaveBeenCalledTimes(1);
@@ -95,8 +95,8 @@ describe('Build Executor', () => {
       context
     );
     expect(execMock).toHaveBeenCalledWith(
-      'npx wdio wdio.generated.config.ts --spec=src/e2e/test.spec.ts',
-      expect.objectContaining({ cwd: './apps/test-e2e' }),
+      'npx wdio apps/test-e2e/wdio.generated.config.ts --spec=src/e2e/test.spec.ts',
+      expect.objectContaining({}),
       expect.any(Function)
     );
     expect(pipe).toHaveBeenCalledTimes(1);
@@ -113,8 +113,8 @@ describe('Build Executor', () => {
       context
     );
     expect(execMock).toHaveBeenCalledWith(
-      'npx wdio wdio.generated.config.ts --suite=test',
-      expect.objectContaining({ cwd: './apps/test-e2e' }),
+      'npx wdio apps/test-e2e/wdio.generated.config.ts --suite=test',
+      expect.objectContaining({}),
       expect.any(Function)
     );
     expect(pipe).toHaveBeenCalledTimes(1);
@@ -130,8 +130,8 @@ describe('Build Executor', () => {
       context
     );
     expect(execMock).toHaveBeenCalledWith(
-      'npx wdio wdio.generated.config.ts',
-      expect.objectContaining({ cwd: './apps/test-e2e' }),
+      'npx wdio apps/test-e2e/wdio.generated.config.ts',
+      expect.objectContaining({}),
       expect.any(Function)
     );
     expect(pipe).toHaveBeenCalledTimes(1);

--- a/packages/webdriverio/src/executors/e2e/lib/run-wdio.ts
+++ b/packages/webdriverio/src/executors/e2e/lib/run-wdio.ts
@@ -12,15 +12,15 @@ import { unlink } from 'node:fs/promises';
 import type { NormalizedSchema } from '../schema';
 
 export async function runWdio(options: NormalizedSchema) {
-  const { projectRoot, configFile, spec, suite, watch } = options;
+  const { configPath, spec, suite, watch } = options;
 
-  let command = `${getPackageManagerCommand().exec} wdio ${configFile}`;
+  let command = `${getPackageManagerCommand().exec} wdio ${configPath}`;
   if (spec) command += ` --spec=${spec}`;
   if (suite) command += ` --suite=${suite}`;
   if (watch) command += ` --watch`;
 
   await new Promise((resolve, reject) => {
-    exec(command, { cwd: projectRoot }, (error, stdout, stderr) => {
+    exec(command, {}, (error, stdout, stderr) => {
       error ? reject(error) : resolve({ stdout, stderr });
     }).stdout.pipe(process.stdout);
 

--- a/packages/webdriverio/src/executors/e2e/schema.d.ts
+++ b/packages/webdriverio/src/executors/e2e/schema.d.ts
@@ -12,7 +12,6 @@ export interface Schema extends WdioOptions {
 }
 
 export interface NormalizedSchema extends Schema {
-  configFile: string;
   configPath: string;
   baseConfigModuleName: string;
   baseConfigPath: string;

--- a/packages/webdriverio/src/generators/project/generator.spec.ts
+++ b/packages/webdriverio/src/generators/project/generator.spec.ts
@@ -2,7 +2,6 @@ import {
   Tree,
   readProjectConfiguration,
   addProjectConfiguration,
-  joinPathFragments,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import generator from './generator';
@@ -48,8 +47,8 @@ describe('project generator', () => {
     };
     await generator(tree, options);
     const config = readProjectConfiguration(tree, 'test-e2e');
-    expect(config.targets.e2e.options.wdioConfig).toBe('wdio.config.ts');
-    const wdioConfigPath = joinPathFragments(config.root, 'wdio.config.ts');
+    const wdioConfigPath = config.targets.e2e.options.wdioConfig;
+    expect(wdioConfigPath).toBe('apps/test-e2e/wdio.config.ts');
     expect(tree.exists(wdioConfigPath)).toBeTruthy();
   });
 

--- a/packages/webdriverio/src/generators/project/lib/add-project-config.ts
+++ b/packages/webdriverio/src/generators/project/lib/add-project-config.ts
@@ -14,7 +14,7 @@ export function addProjectConfig(tree: Tree, options: NormalizedSchema) {
       e2e: {
         executor: '@rbnx/webdriverio:e2e',
         options: {
-          wdioConfig: 'wdio.config.ts',
+          wdioConfig: `${projectRoot}/wdio.config.ts`,
           ...filterWdioOptions(options),
         },
       },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/roozenboom/rbnx/blob/master/CONTRIBUTING.md -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(scope): must begin with lowercase` -->

## Current Behavior

<!-- This is the behavior we have today -->
When the e2e executor is used it runs wdio with a generated config file. This file is stored in the root of the e2e project and is referenced only by the file name. We create a child process to run wdio and configure the working directory (cwd) to the e2e project. With NPM this worked as expected, but when the project is using yarn as a package manager the working directory is not set correctly, resulting in an error `Could not execute "run" due to missing configuration file`

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
This PR changed how we configure the generated configuration in the child process command. Instead of the file name we use the file path relative to the workspace root. We also update the import path for the base configuration to always be relative to the generated config location.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13
